### PR TITLE
FIX: go back to fetching from backend on render

### DIFF
--- a/src/components/Main.svelte
+++ b/src/components/Main.svelte
@@ -42,9 +42,7 @@
 
   async function downloadPDF() {
     try {
-      const response = await fetch(
-        `${import.meta.env.BASE_URL}public/jorgecapcha-cv-eng.pdf`
-      );
+      const response = await fetch("https://portfolio-pdf-api.onrender.com");
       const blob = await response.blob();
 
       // Create a blob URL and trigger download


### PR DESCRIPTION
Fixed problem with pdf downloads, by going back to fetching from the backend on render.