### PR TITLE
FIX: excessive gotop arrow padding

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,14 +16,14 @@
   class="relative flex flex-col max-w-[1600px] mx-auto w-full text-sm sm:text-base min-h-screen"
 >
   <div
-    class={"fixed bottom-0 w-full duration-200 flex p-10 z-[10] " +
+    class={"fixed bottom-0 w-full duration-200 flex p-1 z-[10]" +
       (y > 0
         ? " opacity-full pointer-events-auto"
         : " pointer-events-none opacity-0")}
   >
     <button
       on:click={goTop}
-      class="ml-auto rounded-full aspect-square bg-slate-900 text-violet-400 px-3 sm:px-4 hover:bg-slate-800 cursor-pointer"
+      class="ml-auto rounded-full aspect-square bg-slate-900 text-violet-400 px-3 sm:px-4 hover:bg-slate-800 cursor-pointer -translate-x-6 -translate-y-6"
     >
       <i class="fa-solid fa-arrow-up grid place-items-center aspect-square" />
     </button>


### PR DESCRIPTION
Fixed excessive padding and wrong positioning of the "goTop" arrow to allow all the footer links to work properly.